### PR TITLE
修复动态插入slide组件不更新的bug

### DIFF
--- a/swiper.vue
+++ b/swiper.vue
@@ -32,6 +32,9 @@
     mounted: function() {
       if (!this.swiper) this.swiper = new Swiper(this.$el, this.options)
     },
+    updated: function(){
+      this.swiper.update();
+    },
     beforeDestroy: function() {
       if (!!this.swiper) {
         this.swiper = null


### PR DESCRIPTION
测试环境
vue2.0+  vue-awasome-swiper@master

问题
从后台取得json数据后更新组件发现siwper会有位置错位的情况

修复
在update事件中手动更新swiper