### PR TITLE
add nextTick to mounted life cycle

### DIFF
--- a/swiper.vue
+++ b/swiper.vue
@@ -35,9 +35,11 @@
       }
     },
     mounted: function() {
-      if (!this.swiper && typeof global.window != 'undefined') {
-        this.swiper = new Swiper(this.$el, this.options)
-      }
+      this.$nextTick(() => {
+        if (!this.swiper && typeof global.window != 'undefined') {
+          this.swiper = new Swiper(this.$el, this.options)
+        }
+      })
     },
     updated: function(){
       this.swiper.update()


### PR DESCRIPTION
I make the core code of `mounted` life cycle into a `$nextTick` function, as to ensure state manipulation won't take place before DOM insertion.

This would erase any glitch that caused by life cycle malfunction. Such as that initialization code doesn't run properly in `mounted` hook, which causes thumbs won't trigger slider change, when under a vue-router environment.

[Vue API#nextTick](https://vuejs.org/v2/api/#Vue-nextTick)

[Vue Best Practices - Understanding Async Updates](http://012.vuejs.org/guide/best-practices.html#Understanding_Async_Updates)

This is a necessary bugfix.