### PR TITLE
Adds check for existing $parent

### DIFF
--- a/src/slide.vue
+++ b/src/slide.vue
@@ -17,7 +17,7 @@
     },
     mounted: function() {
       this.update()
-      if (this.$parent.options.slideClass) {
+      if (this.$parent && this.$parent.options && this.$parent.options.slideClass) {
         this.slideClass = this.$parent.options.slideClass
       }
     },


### PR DESCRIPTION
This fixes the following error message that is in my console.

```
TypeError: Cannot read property 'slideClass' of undefined
  at VueComponent.mounted (slide.vue?7c49:21)
  ...
```