### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ Swiper.use({
 ```vue
 <template>
   <swiper :options="swiperOption">
-    <swiper-slide v-for="slide in swiperSlides">I'm Slide {{ slide }}</swiper-slide>
+    <swiper-slide v-for="(slide, index) in swiperSlides" :key="index">I'm Slide {{ slide }}</swiper-slide>
     <div class="swiper-pagination" slot="pagination"></div>
   </swiper>
 </template>


### PR DESCRIPTION
When I tried Async data example of README, the following warning was displayed at the time of execution.

> (Emitted value instead of an instance of Error) <swiper-slide v-for = "slide in swiperSlides">: component lists rendered with v-for should have explicit keys. See https://vuejs.org/guide/list. html # key for more info.


I modified sample code to pass the index value as key, so please check and merge.