### PR TITLE
Fix: When destroying a component with an not initialized swiper.

### DIFF
--- a/dist/ssr.js
+++ b/dist/ssr.js
@@ -77,7 +77,9 @@ var swiperDirective = function swiperDirective(globalOptions) {
       var instanceName = getInstanceName(el, binding, vnode);
       var swiper = vnode.context[instanceName];
       if (swiper) {
-        swiper.destroy && swiper.destroy();
+        if (swiper.destroy && swiper.initialized === true) {
+          swiper.destroy();
+        }
         delete vnode.context[instanceName];
       }
     }

--- a/src/ssr.js
+++ b/src/ssr.js
@@ -113,7 +113,9 @@ const swiperDirective = globalOptions => {
       const instanceName = getInstanceName(el, binding, vnode)
       const swiper = vnode.context[instanceName]
       if (swiper) {
-        swiper.destroy && swiper.destroy()
+        if (swiper.destroy && swiper.initialized === true) {
+          swiper.destroy();
+        }
         delete vnode.context[instanceName]
       }
     }


### PR DESCRIPTION
When you destroy a component, where swiper not initialized (swiper.initialized === undefined  || swiper.initialized === false), then an error occurs: "Failed to execute 'remove' on 'DOMTokenList'."

Fix the code on the per-line 115 file `~/src/ssr.js` on:
```javascript
if (swiper) {
  if (swiper.destroy && swiper.initialized === true) {
    swiper.destroy();
  }
  delete vnode.context[instanceName]
}
```
that not to destroy the not yet initialized swiper../

https://github.com/surmon-china/vue-awesome-swiper/issues/340