### PR TITLE
add init event

### DIFF
--- a/src/swiper.vue
+++ b/src/swiper.vue
@@ -69,7 +69,8 @@
     'fromEdge',
     'setTranslate',
     'setTransition',
-    'resize'
+    'resize',
+    'init'
   ]
 
   // export


### PR DESCRIPTION
Hello, `init` event is missing. I've added it to the list.