### PR TITLE
Account for transition periode

### DIFF
--- a/dist/ssr.js
+++ b/dist/ssr.js
@@ -77,7 +77,10 @@ var swiperDirective = function swiperDirective(globalOptions) {
       var instanceName = getInstanceName(el, binding, vnode);
       var swiper = vnode.context[instanceName];
       if (swiper) {
-        swiper.destroy && swiper.destroy();
+        setTimeout(function() {
+          swiper.destroy && swiper.destroy();
+          delete vnode.context[instanceName];
+        }, 1000);
         delete vnode.context[instanceName];
       }
     }

--- a/dist/ssr.js
+++ b/dist/ssr.js
@@ -81,7 +81,6 @@ var swiperDirective = function swiperDirective(globalOptions) {
           swiper.destroy && swiper.destroy();
           delete vnode.context[instanceName];
         }, 1000);
-        delete vnode.context[instanceName];
       }
     }
   };

--- a/src/ssr.js
+++ b/src/ssr.js
@@ -117,7 +117,6 @@ const swiperDirective = globalOptions => {
           swiper.destroy && swiper.destroy()
           delete vnode.context[instanceName]
         }, 1000)
-        delete vnode.context[instanceName]
       }
     }
   }

--- a/src/ssr.js
+++ b/src/ssr.js
@@ -113,7 +113,10 @@ const swiperDirective = globalOptions => {
       const instanceName = getInstanceName(el, binding, vnode)
       const swiper = vnode.context[instanceName]
       if (swiper) {
-        swiper.destroy && swiper.destroy()
+        setTimeout(function() {
+          swiper.destroy && swiper.destroy()
+          delete vnode.context[instanceName]
+        }, 1000)
         delete vnode.context[instanceName]
       }
     }


### PR DESCRIPTION
When using a SPA one may have a transition from one page to another. Vue will call the beforeDestroy listener before the transition is over. To compensate this change adds a delay of 1 second before the slider gets destroyed.

Other solutions are welcome but I couldn't find one in the few minutes I had. This change should not have a negative impact on any application as it only delays the removal.