### PR TITLE
Update README.md for Swiper 6.4.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,27 @@ yarn add swiper@5.x vue-awesome-swiper
 
 ``` javascript
 import Vue from 'vue'
+
+// import core version + navigation, pagination modules（>= Swiper 6.x）
+import SwiperClass, { Navigation, Pagination, /* add some modules if you need */ } from "swiper";
+// configure Swiper to use modules
+SwiperClass.use([Navigation, Pagination]);
+
 import VueAwesomeSwiper from 'vue-awesome-swiper'
 
-// import style (>= Swiper 6.x)
+// ----------------------------------------------------------------------------------------
+// import style of all modules (>= Swiper 6.x)
+// all Swiper styles including all components styles (like Navigation, Pagination, etc.)
+// ----------------------------------------------------------------------------------------
 import 'swiper/swiper-bundle.css'
+
+// import style of only use module (>= Swiper 6.x)
+// only core Swiper styles
+import 'swiper/swiper.scss';
+// styles required for Navigation component
+import 'swiper/components/navigation/navigation.scss';
+// styles required for Pagination component
+import 'swiper/components/pagination/pagination.scss';
 
 // import style (<= Swiper 5.x)
 import 'swiper/css/swiper.css'
@@ -63,10 +80,26 @@ Vue.use(VueAwesomeSwiper, /* { default options with global component } */)
 ### Local Registration
 
 ```javascript
+// import core version + navigation, pagination modules（>= Swiper 6.x）
+import SwiperClass, { Navigation, Pagination, /* add some modules if you need */ } from "swiper";
+// configure Swiper to use modules
+SwiperClass.use([Navigation, Pagination]);
+
 import { Swiper, SwiperSlide, directive } from 'vue-awesome-swiper'
 
-// import style (>= Swiper 6.x)
+// ----------------------------------------------------------------------------------------
+// import style of all modules (>= Swiper 6.x)
+// all Swiper styles including all components styles (like Navigation, Pagination, etc.)
+// ----------------------------------------------------------------------------------------
 import 'swiper/swiper-bundle.css'
+
+// import style of only use module (>= Swiper 6.x)
+// only core Swiper styles
+import 'swiper/swiper.scss';
+// styles required for Navigation component
+import 'swiper/components/navigation/navigation.scss';
+// styles required for Pagination component
+import 'swiper/components/pagination/pagination.scss';
 
 // import style (<= Swiper 5.x)
 import 'swiper/css/swiper.css'
@@ -81,6 +114,33 @@ export default {
   }
 }
 ```
+### Registration Appendix
+
+From Swiper 6.x, by default exports only core version without additional modules (like Navigation, Pagination etc.)  
+So you need to import and configure them too.
+
+| Module Name | Import Module | Import Module Style<br/>(can use type ".min.css", ".less" and ".scss") |
+|:---|:---|:---|
+| Virtual Slides | Virtual | - |
+| Keyboard Control | Keyboard | - |
+| Mousewheel Control | Mousewheel |- | 
+| Navigation | Navigation | components/navigation/navigation.min.css |
+| Pagination | Pagination | components/pagination/pagination.min.css |
+| Scrollbar | Scrollbar | components/scrollbar/scrollbar.min.css |
+| Parallax | Parallax | - |
+| Zoom | Zoom | components/zoom/zoom.min.css |
+| Lazy | Lazy | components/lazy/lazy.min.css |
+| Controller | Controller | - |
+| Accessibility | A11y | components/controller/controller.min.css<br/>components/a11y/a11y.min.css |
+| History Navigation | History | - |
+| Hash Navigation | HashNavigation | - |
+| Autoplay | Autoplay | - |
+| Fade Effect | EffectFade | components/effect-fade/effect-fade.min.css |
+| Cube Effect | EffectCube | components/effect-cube/effect-cube.min.css |
+| Flip Effect | EffectFlip | components/effect-flip/effect-flip.min.css |
+| Coverflow Effect | EffectCoverflow | components/effect-coverflow/effect-coverflow.min.css |
+| Thumbs | Thumbs | components/thumbs/thumbs.min.css |
+||||
 
 ### CDN
 

--- a/README.md
+++ b/README.md
@@ -65,11 +65,11 @@ import 'swiper/swiper-bundle.css'
 
 // import style of only use module (>= Swiper 6.x)
 // only core Swiper styles
-import 'swiper/swiper.scss';
+import 'swiper/swiper.min.css';
 // styles required for Navigation component
-import 'swiper/components/navigation/navigation.scss';
+import 'swiper/components/navigation/navigation.min.css';
 // styles required for Pagination component
-import 'swiper/components/pagination/pagination.scss';
+import 'swiper/components/pagination/pagination.min.css';
 
 // import style (<= Swiper 5.x)
 import 'swiper/css/swiper.css'
@@ -95,11 +95,11 @@ import 'swiper/swiper-bundle.css'
 
 // import style of only use module (>= Swiper 6.x)
 // only core Swiper styles
-import 'swiper/swiper.scss';
+import 'swiper/swiper.min.css';
 // styles required for Navigation component
-import 'swiper/components/navigation/navigation.scss';
+import 'swiper/components/navigation/navigation.min.css';
 // styles required for Pagination component
-import 'swiper/components/pagination/pagination.scss';
+import 'swiper/components/pagination/pagination.min.css';
 
 // import style (<= Swiper 5.x)
 import 'swiper/css/swiper.css'

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "release": ". ./scripts/release.sh"
   },
   "peerDependencies": {
-    "swiper": "^5.2.0",
+    "swiper": "^5.2.0 || ^6.4.5",
     "vue": "2.x"
   },
   "devDependencies": {


### PR DESCRIPTION
Swiper 6.4.5 has some changes. 
I updated the README.md for this library with those change.

The verification was performed in the following environment.

```
"swiper": "^6.4.5",
"vue-awesome-swiper": "^4.1.1",
```

Therefore, I was added swiper version "6.4.5"  to peerDependencies.
